### PR TITLE
Adjust tolerance to allow for slight differences in exp implementation.

### DIFF
--- a/tests/testthat/testCauchyREML.R
+++ b/tests/testthat/testCauchyREML.R
@@ -143,7 +143,7 @@ test_that("testRootingStrategies", {
   ## disp 0
   ll1 <- logDensityTipsCauchy(tree, trait, NULL, 0, method = "reml", rootTip = rootTip)
   ll2 <- logDensityTipsCauchy(tree = retree, tipTrait = tipTraitBis, root.value = root.value, disp = 0, method = "random.root")
-  expect_equal(ll1, ll2, tolerance = 1e-5)
+  expect_equal(ll1, ll2, tolerance = 1e-4)
   
   ## disp 1.3
   ll1 <- logDensityTipsCauchy(tree, trait, NULL, 1.3, method = "reml", rootTip = rootTip)


### PR DESCRIPTION
Unfortunately the package does not pass its own tests with mingw-w64 v12 on Windows. Rtools45 still uses mingw-w64 v11, to allow time for packages not working with v12 to be adjusted. so one has to use a special build to see this problem now. The problem results in failure

```
  ── Failure ('testCauchyREML.R:146:3'): testRootingStrategies ───────────────────
  `ll1` (`actual`) not equal to `ll2` (`expected`).

    `actual`: -3349.02
  `expected`: -3349.31
```
and is caused by that mingw-w64 uses exp() from UCRT, the Windows C runtime. In v11 and earlier versions, a replacement implementation has been used, which has been more precise.

However, all the calls to exp() used in the tests are within 1 ULP from the previous version in v11, so, the differences are very small - small enough that this cannot be argued to be a bug in mingw-w64, but rather seems to be unreasonably small tolerance of the test. This patch increases the tolerance of the test so that it passes also with mingw-w64 v12.
